### PR TITLE
Improve GitHub project argument parsing

### DIFF
--- a/is-it-slop/src/cli.rs
+++ b/is-it-slop/src/cli.rs
@@ -1,10 +1,14 @@
+use std::str::FromStr;
+
 use clap::Parser;
+use color_eyre::eyre::{OptionExt, bail};
+use reqwest::Url;
 
 #[derive(Parser, Debug)]
 #[command(version, about, arg_required_else_help = true)]
 pub struct Args {
     /// Either <USER>/<REPO> or full URL
-    pub github_project_or_url: String,
+    pub github_project_or_url: GitHubProject,
 
     /// Emit non-zero exit code if any slop detected
     #[arg(long)]
@@ -13,4 +17,48 @@ pub struct Args {
     /// HEAD is a reasonable standard, but you can manually specify branch name or specific commit
     #[arg(long, default_value = "HEAD")]
     pub git_ref: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct GitHubProject {
+    pub owner: String,
+    pub repo: String,
+    pub url: Option<Url>,
+}
+
+impl FromStr for GitHubProject {
+    type Err = color_eyre::Report;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(url) = Url::parse(s) {
+            if url.host_str() != Some("github.com") {
+                bail!("not a GitHub URL!");
+            }
+            let mut segments = url
+                .path_segments()
+                .ok_or_eyre("cannot parse cannot-be-a-base URL")?;
+            let (Some(owner), Some(repo), None) =
+                (segments.next(), segments.next(), segments.next())
+            else {
+                bail!("path segments do not match format '/<owner>/<repository>'");
+            };
+            return Ok(GitHubProject {
+                owner: owner.to_owned(),
+                repo: repo.to_owned(),
+                url: Some(url),
+            });
+        }
+
+        let mut segments = s.split('/');
+        let (Some(owner), Some(repo), None) = (segments.next(), segments.next(), segments.next())
+        else {
+            bail!("argument does not match format '<owner>/<repository>'");
+        };
+
+        Ok(GitHubProject {
+            owner: owner.to_owned(),
+            repo: repo.to_owned(),
+            url: None,
+        })
+    }
 }

--- a/is-it-slop/src/crate_metadata.rs
+++ b/is-it-slop/src/crate_metadata.rs
@@ -6,6 +6,8 @@ use semver::{Version, VersionReq};
 use serde::Deserialize;
 use toml::Table;
 
+use crate::GitHubProject;
+
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct CargoToml {
@@ -108,14 +110,15 @@ pub fn is_old_edition(edition_str: &str) -> color_eyre::Result<bool> {
 }
 
 pub async fn fetch_cargo_toml(
-    github_project: &str,
+    github_project: &GitHubProject,
     git_ref: &str,
     client: &Client,
 ) -> color_eyre::Result<CargoToml> {
     let cargo_toml_str = client
         .get(format!(
-            "https://raw.githubusercontent.com/{}/{}/Cargo.toml",
-            github_project, git_ref,
+            "https://raw.githubusercontent.com/{owner}/{repo}/{git_ref}/Cargo.toml",
+            owner = github_project.owner,
+            repo = github_project.repo,
         ))
         .send()
         .await

--- a/is-it-slop/src/github.rs
+++ b/is-it-slop/src/github.rs
@@ -4,6 +4,8 @@ use jiff::Timestamp;
 use reqwest::Client;
 use serde::Deserialize;
 
+use crate::GitHubProject;
+
 #[derive(Deserialize, Debug)]
 pub struct GithubRepoDetails {
     pub created_at: Timestamp,
@@ -19,11 +21,14 @@ static SUSSY_FILES: &[&str] = &[
 ];
 
 pub async fn fetch_repo_details(
-    github_project: &str,
+    github_project: &GitHubProject,
     client: &Client,
 ) -> color_eyre::Result<GithubRepoDetails> {
     client
-        .get(String::from("https://api.github.com/repos/") + github_project)
+        .get(format!(
+            "https://api.github.com/repos/{}/{}",
+            github_project.owner, github_project.repo
+        ))
         .send()
         .await
         .wrap_err("couldn't fetch repo details, are you sure it exists?")?
@@ -32,7 +37,11 @@ pub async fn fetch_repo_details(
         .map_err(color_eyre::Report::from)
 }
 
-pub async fn find_sussy_files(github_project: &str, git_ref: &str, client: &Client) -> Vec<String> {
+pub async fn find_sussy_files(
+    github_project: &GitHubProject,
+    git_ref: &str,
+    client: &Client,
+) -> Vec<String> {
     println!("\nchecking for sussy files in the repo");
 
     stream::iter(SUSSY_FILES)
@@ -57,7 +66,7 @@ pub async fn find_sussy_files(github_project: &str, git_ref: &str, client: &Clie
 }
 
 pub async fn fetch_gitignore(
-    github_project: &str,
+    github_project: &GitHubProject,
     git_ref: &str,
     client: &Client,
 ) -> color_eyre::Result<String> {
@@ -83,9 +92,14 @@ pub fn find_gitignored_sussy_files(gitignore: &str) -> Vec<&str> {
         .collect()
 }
 
-pub fn format_raw_github_file_url(github_project: &str, git_ref: &str, path: &str) -> String {
+pub fn format_raw_github_file_url(
+    github_project: &GitHubProject,
+    git_ref: &str,
+    path: &str,
+) -> String {
     format!(
-        "https://raw.githubusercontent.com/{}/{}/{}",
-        github_project, git_ref, path
+        "https://raw.githubusercontent.com/{owner}/{repo}/{git_ref}/{path}",
+        owner = github_project.owner,
+        repo = github_project.repo,
     )
 }

--- a/is-it-slop/src/main.rs
+++ b/is-it-slop/src/main.rs
@@ -1,5 +1,4 @@
 use clap::Parser;
-use color_eyre::eyre::OptionExt;
 use jiff::{Unit, ZonedDifference, tz::TimeZone};
 use reqwest::Client;
 
@@ -7,6 +6,7 @@ mod cli;
 mod crate_metadata;
 mod github;
 
+pub use crate::cli::GitHubProject;
 use crate::{
     cli::Args,
     crate_metadata::{fetch_cargo_toml, is_old_edition, look_for_outdated_dependencies},
@@ -24,16 +24,18 @@ async fn main() -> color_eyre::Result<()> {
         .install()?;
 
     let args = Args::parse();
+    let github_project = args.github_project_or_url;
 
     let client = Client::builder().user_agent(USER_AGENT).build()?;
 
     let mut slop_score_motivations = Vec::new();
 
-    let github_project = parse_github_project(&args.github_project_or_url)?;
+    println!(
+        "checking 'https://github.com/{}/{}'",
+        github_project.owner, github_project.repo
+    );
 
-    println!("checking 'https://github.com/{}'", github_project);
-
-    let repo = fetch_repo_details(github_project, &client).await?;
+    let repo = fetch_repo_details(&github_project, &client).await?;
 
     let now_utc = jiff::Timestamp::now().to_zoned(TimeZone::UTC);
     let created_utc = repo.created_at.to_zoned(TimeZone::UTC);
@@ -60,7 +62,7 @@ async fn main() -> color_eyre::Result<()> {
         _ => (),
     }
 
-    let cargo_toml = fetch_cargo_toml(github_project, &args.git_ref, &client).await?;
+    let cargo_toml = fetch_cargo_toml(&github_project, &args.git_ref, &client).await?;
 
     if let Some(package) = cargo_toml.package
         && let Some(edition) = package.edition
@@ -103,9 +105,9 @@ async fn main() -> color_eyre::Result<()> {
         }
     }
 
-    let sussy_files_present = find_sussy_files(github_project, &args.git_ref, &client).await;
+    let sussy_files_present = find_sussy_files(&github_project, &args.git_ref, &client).await;
 
-    let gitignore = fetch_gitignore(github_project, &args.git_ref, &client).await?;
+    let gitignore = fetch_gitignore(&github_project, &args.git_ref, &client).await?;
     let sussy_files_gitignored = find_gitignored_sussy_files(&gitignore);
 
     let slop_score = outdated_dependencies.len()
@@ -143,21 +145,4 @@ async fn main() -> color_eyre::Result<()> {
     }
 
     Ok(())
-}
-
-pub fn parse_github_project(github_project_or_url: &str) -> color_eyre::Result<&str> {
-    if !github_project_or_url.starts_with("http") {
-        // already what we want! hopefully..
-        return Ok(github_project_or_url);
-    }
-
-    let (_, rest) = github_project_or_url
-        .split_once("github.com/")
-        .ok_or_eyre("not a GitHub URL!")?;
-
-    let end_index = rest
-        .match_indices('/')
-        .nth(1)
-        .map_or(rest.len(), |(i, _)| i);
-    Ok(&rest[..end_index])
 }


### PR DESCRIPTION
Hej!

This is a bit of a _drive-by-PR_, so if you don't like this implementation feel free to close and disregard or let me know what you'd like me to change and I'll make edits :)

This change improves parsing of the `github_project_or_url` CLI argument and introduces a `GitHubProject` struct that groups project segments rather than treating the argument as just a string. There are a few edge cases that are now covered by the additional parsing logic.
